### PR TITLE
feat: add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,3 @@ repos:
     rev: v2.7.1
     hooks:
       - id: prettier
-
-  - repo: https://github.com/psf/black
-    rev: 20.8b1
-    hooks:
-      - id: black
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8


### PR DESCRIPTION
Добавил проверку prettier, black, flake8 при коммите.
Для работы нужно установить:
pip install pre-commit
И запустить:
pre-commit install
Для того чтобы прогнать тест по всему коду, а не только по коммиту:
pre-commit run --all-files